### PR TITLE
[update] update colour refrences to gengo-bg in docs

### DIFF
--- a/docs/_includes/components/badges.html
+++ b/docs/_includes/components/badges.html
@@ -69,5 +69,5 @@
   ...
 </ul>
 {% endhighlight %}
-  <div>If the background is <code>#f4f4f4</code>, the active state becomes <code>#ffffff</code></div>
+  <div>If the background is <code>#eeeeee</code>, the active state becomes <code>#ffffff</code></div>
 </div>

--- a/docs/_includes/components/progress-bar.html
+++ b/docs/_includes/components/progress-bar.html
@@ -30,7 +30,7 @@
 
   <h2>Contextual alternatives</h2>
   <br>
-  <div>If the background is <code>#f4f4f4</code>, the active state becomes <code>#ffffff</code></div>
+  <div>If the background is <code>#eeeeee</code>, the active state becomes <code>#ffffff</code></div>
   <br>
   <div class="bs-example">
     <div class="progress">

--- a/docs/_includes/style/colors.html
+++ b/docs/_includes/style/colors.html
@@ -36,7 +36,7 @@
     </div>
     <div class="item col-xs-12 col-sm-3">
       <div class="color-box gengo-bg"></div>
-      <strong>GENGO BG</strong> <span class="color">#F4F4F4</span>
+      <strong>GENGO BG</strong> <span class="color">#EEEEEE</span>
     </div>
 
     <div class="item col-xs-12 col-sm-6">


### PR DESCRIPTION
this PR updates the colourcode references to Gengo background in docs; `#f4f4f4` -> `#eeeeee`