### PR TITLE
[#89968596] requested by Sarah

### DIFF
--- a/docs/_includes/style/introduction.html
+++ b/docs/_includes/style/introduction.html
@@ -1,7 +1,7 @@
 <div class="box">
   <h1 id="introduction">Introducing the Gengo Style Guide</h1>
   <hr/>
-  <p>Since Gengo was founded, the web and its technology have changed a lot. In that time our product has grown organically as well, making it a challenge for us to scale at speed in all areas of our platform.</p>
+  <p>Since our founding in 2008, the web and its technology have changed significantly. In that time our product has grown organically as well, making it a challenge for us to scale at speed in all areas of our platform.</p>
   <p>To carry us into the future, we’ve created a style guide. This guide will help us build consistently and quickly without needing oversight for every pixel and will also help us focus more on workflows and logic rather than bits and pieces like buttons and list items. It outlines:</p>
   <ul>
     <li>Logo, color and asset usage</li>

--- a/docs/_includes/voice/style-guide.html
+++ b/docs/_includes/voice/style-guide.html
@@ -168,10 +168,6 @@
     </thead>
     <tbody>
       <tr>
-        <td>and</td>
-        <td>&</td>
-      </tr>
-      <tr>
         <td>ecommerce (Ecommerce if capitalized)</td>
         <td>e-commerce, ECommerce</td>
       </tr>


### PR DESCRIPTION
From Sarah:

David, could we remove the "use this, not that" for ampersands (we're using them now) in the Style Guide? Could you also change the first sentence in the Style Guide intro to:

Since our founding in 2008, the web and its technology have changed significantly.