### PR TITLE
Fix missing select2-spinner.gif

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -248,7 +248,8 @@ module.exports = (grunt) ->
         expand:true
         cwd:'<%= assets.bower %>/select2'
         src: [
-          'select2*.png'
+          'select2*.png',
+          'select2*.gif',
         ]
         dest: '<%= assets.css %>'
       'select2-js':


### PR DESCRIPTION
### Description
- Fix missing `select2-spinner.gif` in `dist/css` folder

### Screenshot
![screen shot 2017-01-20 at 11 16 15 am](https://cloud.githubusercontent.com/assets/8102493/22134452/01308980-df02-11e6-8eae-945c58c321a9.png)
