### PR TITLE
Fix popper js error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   - bower_components
   - node_modules
 node_js:
-- 4.4.3
+- 4.7.0
 install: "./setup.sh"
 script: npm run build
 after_success: "./deploy.sh"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "gengo-style-guide",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Gengo style guide",
   "dependencies": {
     "bootstrap-sass-official": "~3.3.6",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,8 @@
     "x-editable": "~1.5.1",
     "typeahead.js": "~0.10.5",
     "select2": "~3.5.1",
-    "moment": "~2.8.2"
+    "moment": "~2.8.2",
+    "bootstrap": "~3.3.7"
   },
   "devDependencies": {
     "bootstrap-docs": "https://github.com/twbs/bootstrap.git#gh-pages"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gengo",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Gengo style guide",
   "homepage": "https://github.com/gengo/style-guide",
   "author": "Gengo, Inc.",


### PR DESCRIPTION
## Description
- Fix popper.js error when upgrading the package, [bootstrap-multiselect](https://github.com/davidstutz/bootstrap-multiselect) installs the latest bootstrap 4 because of the specified version in its [bower.json](https://github.com/davidstutz/bootstrap-multiselect/blob/master/bower.json#L21) but unfortunately bootstrap 4 needed to install [popper.js](https://popper.js.org/) so I decided for us to stay for a while in bootstrap 3 
- [bootstrap-sass](https://github.com/twbs/bootstrap-sass) is only for bootstrap 2 and 3

## Reference Links
- https://github.com/twbs/bootstrap/issues/23381 
- https://getbootstrap.com/docs/4.0/getting-started/webpack/#importing-javascript

## Screenshot 
<img width="1280" alt="screen shot 2018-01-24 at 10 17 07 pm" src="https://user-images.githubusercontent.com/8102493/35337736-ef843e98-0156-11e8-910a-e4d48ffeb6f0.png">
