### PR TITLE
[LOPS-1024] Fix bootstrap-multiselect version to 0.9.13

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "description": "Gengo style guide",
   "dependencies": {
     "bootstrap-sass-official": "~3.3.6",
-    "bootstrap-multiselect": "~0.9.13",
+    "bootstrap-multiselect": "0.9.13",
     "x-editable": "~1.5.1",
     "typeahead.js": "~0.10.5",
     "select2": "~3.5.1",


### PR DESCRIPTION
Fix `bootstrap-multiselect` version to 0.9.13. Latest version of `0.9` requires bootstrap-5.1.3 even though other libraries expect bootstrap-4.x.

![image](https://user-images.githubusercontent.com/44186736/149484677-977ea54f-0c3b-4487-882a-5c104d52fce3.png)

